### PR TITLE
Fixed Alchemy: Greater Arcane Protection Potion

### DIFF
--- a/Core/Spells.lua
+++ b/Core/Spells.lua
@@ -8285,7 +8285,7 @@ GetSpellInfoVanillaDB = {
 			["craftQuantityMax"] = "",
 			["reagents"] = {
 				[1] = {11176},
-				[2] = {13465},
+				[2] = {13463},
 				[3] = {8925},
 			},
 		},


### PR DESCRIPTION
Corrected reagents for Alchemy: Greater Arcane Protection Potion (Dreamfoil instead of Mountain Silversage)